### PR TITLE
Set default mismatch tolerance to 0.0001

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,12 @@ var webdrivercss = require('./webdrivercss'),
 
 function loadConfig(testCase) {
 	return {
-		webdrivercss: webdrivercss.getConfig(testCase.group, testCase.screenWidth, testCase.updateBaseline),
+		webdrivercss: webdrivercss.getConfig(
+			testCase.group,
+			testCase.screenWidth,
+			testCase.misMatchTolerance,
+			testCase.updateBaseline
+		),
 		browser: browser.getConfig(testCase.browser, testCase.useMobile, 'verbose'),
 		webdrivercssTestCase: [{
 			name: testCase.name

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -7,7 +7,9 @@ function load(mocha, customTestCase) {
 		browser: 'chrome',
 		useMobile: false,
 		updateBaseline: false,
-		misMatchTolerance: 0,
+		// webdrivercss doesn't accept 0
+		// see https://github.com/webdriverio/webdrivercss/blob/v1.1.10/lib/webdrivercss.js#L29
+		misMatchTolerance: 0.0001,
 		timeout: 999999
 	}, testCase, custom = customTestCase || {};
 

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -7,6 +7,7 @@ function load(mocha, customTestCase) {
 		browser: 'chrome',
 		useMobile: false,
 		updateBaseline: false,
+		misMatchTolerance: 0,
 		timeout: 999999
 	}, testCase, custom = customTestCase || {};
 

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -1,10 +1,11 @@
 var path = require('path');
 
-function getConfig(testGroupName, screenWidth, updateBaseline) {
+function getConfig(testGroupName, screenWidth, misMatchTolerance, updateBaseline) {
 	var options = {
 		screenshotRoot: path.join('./visuals', testGroupName),
 		failedComparisonRoot: path.join('./visuals/', testGroupName, 'diff'),
-		screenWidth: screenWidth
+		screenWidth: screenWidth,
+		misMatchTolerance: misMatchTolerance
 	};
 
 	if (updateBaseline) {


### PR DESCRIPTION
Webdrivercss doesn't accept `misMatchTolerance: 0`, see https://github.com/webdriverio/webdrivercss/blob/v1.1.10/lib/webdrivercss.js#L29
